### PR TITLE
Check Python versions

### DIFF
--- a/scripts/asciidoctor-text/convert-it-all.py
+++ b/scripts/asciidoctor-text/convert-it-all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """Utility script to convert OCP docs from adoc to plain text."""
 

--- a/scripts/generate_packages_to_prefetch.py
+++ b/scripts/generate_packages_to_prefetch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 """Generate list of packages to be prefetched in Cachi2 and used in Konflux for hermetic build.
 
@@ -147,7 +147,7 @@ def generate_packages_to_be_build(work_directory):
 
     # generate file requirements-build.in
     command = (
-        "python pip_find_builddeps.py requirements.txt --append "
+        "python3 pip_find_builddeps.py requirements.txt --append "
         + f"--only-write-on-update --ignore-errors --allow-binary -o {infile}"
     )
     shell(command, work_directory)

--- a/scripts/get_ocp_plaintext_docs.sh
+++ b/scripts/get_ocp_plaintext_docs.sh
@@ -9,7 +9,7 @@ rm -rf ocp-product-docs-plaintext/${OCP_VERSION}
 
 git clone --single-branch --branch enterprise-${OCP_VERSION} https://github.com/openshift/openshift-docs.git
 
-python scripts/asciidoctor-text/convert-it-all.py -i openshift-docs -t openshift-docs/_topic_maps/_topic_map.yml \
+python3 scripts/asciidoctor-text/convert-it-all.py -i openshift-docs -t openshift-docs/_topic_maps/_topic_map.yml \
     -d openshift-enterprise -o ocp-product-docs-plaintext/${OCP_VERSION} -a scripts/asciidoctor-text/${OCP_VERSION}/attributes.yaml
 
 for f in $(cat config/exclude.conf); do


### PR DESCRIPTION
Some distros (e.g RHEL 9.4) does not have the "python" command, instead "python3" should be used.

The "python3" command should now be universal and since these scripts does not work with python2.* I think we can start explicitly using "python3" directly.