### PR TITLE
    Parallelize data-loading for OpenStack documents

### DIFF
--- a/scripts/common_embeddings.py
+++ b/scripts/common_embeddings.py
@@ -159,14 +159,17 @@ def save_metadata(start_time, args, embedding_dimension,
         file.write(json.dumps(metadata))
 
 
-def process_documents(docs_dir, metadata_func=None,
-                      required_exts=None, file_extractor=None):
+def process_documents(docs_dir, metadata_func=None, required_exts=None,
+                      file_extractor=None, num_workers=0):
+    if num_workers <= 0:
+        num_workers = None
+
     return SimpleDirectoryReader(
         docs_dir,
         recursive=True,
         file_metadata=metadata_func,
         required_exts=required_exts,
-        file_extractor=file_extractor).load_data()
+        file_extractor=file_extractor).load_data(num_workers=num_workers)
 
 
 def get_settings(chunk_size, chunk_overlap, model_dir):


### PR DESCRIPTION
A new --workers (-w) parameter for the scripts/generate_embeddings_openstack.py.
    
When set, it will use the specified number of workers to parallelize the loading of the OpenStack documents. Here's some results I got in my local environment testing:

Without parallelization:
    
real    15m47.039s
user    444m36.493s
sys     60m50.018s
    
With parallelization (10 workers):
    
real    10m12.806s
user    437m4.693s
sys     58m32.437s