### PR TITLE
Remove the -W flag from OpenStack doc script

### DIFF
--- a/scripts/get_openstack_plaintext_docs.sh
+++ b/scripts/get_openstack_plaintext_docs.sh
@@ -23,7 +23,7 @@ deps =
   -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$OS_VERSION}
   -r{toxinidir}/doc/requirements.txt
 commands =
-  sphinx-build -W --keep-going -j auto -b text doc/source doc/build/text
+  sphinx-build --keep-going -j auto -b text doc/source doc/build/text
 "
 # The current directory where the script was invoked
 CURR_DIR=$(pwd)


### PR DESCRIPTION
The -W flag makes sphinx-builder to fail on a warning [0], turning warnings into errors. We do not need to be that strict.

[0] https://www.sphinx-doc.org/en/master/man/sphinx-build.html