### PR TITLE
Adding .pdm-python to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,7 @@ cython_debug/
 
 # rag-content specific
 embeddings_model/
+
+# PDM
+
+.pdm-python


### PR DESCRIPTION
This file didn't come included as part of standard .gitignore for python.

https://pdm-project.org/latest/usage/project/#choose-a-python-interpreter 