### PR TITLE
Metadata are now processed by a callback object

### DIFF
--- a/scripts/generate_embeddings_openstack.py
+++ b/scripts/generate_embeddings_openstack.py
@@ -2,18 +2,16 @@
 
 """Utility script to generate embeddings."""
 
-import multiprocessing
 import os
 import sys
 import time
-from typing import Dict
 
 # Add the common_embedding.py to the Python path
 scripts_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(scripts_dir)
 
 from common_embeddings import (
-    file_metadata_func,
+    FileMetadataProcessor,
     get_common_arg_parser,
     filter_out_invalid_nodes,
     save_index,
@@ -26,43 +24,28 @@ from common_embeddings import (
 # The OpenStack documentation base URL
 OS_DOCS_ROOT_URL = "https://docs.openstack.org"
 
+class OpenstackDocsMetadataProcessor(FileMetadataProcessor):
 
-class OSMetadata(object):
-
-    def __init__(self, docs_dir, base_url):
-        super(OSMetadata, self).__init__()
-        self._base_path = os.path.abspath(docs_dir)
+    def __init__(self, docs_path):
+        super().__init__()
+        self._base_path = os.path.abspath(docs_path)
         if self._base_path.endswith('/'):
             self._base_path = self._base_path[:-1]
 
-        self.base_url = base_url
+        self.base_url = docs_path
 
-    def set_metadata(self, file_path: str) -> Dict:
-        """Populate metadata for an OpenStack documentation page.
-
-        Args:
-            file_path: str: file path in str
-        """
-        docs_url = lambda file_path: (  # noqa: E731
+    def url_function(self, file_path):
+        return (  # noqa: E731
             self.base_url
             + file_path.removeprefix(self._base_path).removesuffix("txt")
             + "html"
         )
-        return file_metadata_func(file_path, docs_url)
-
 
 if __name__ == "__main__":
 
     start_time = time.time()
 
     parser = get_common_arg_parser()
-    parser.add_argument(
-        "-w",
-        "--workers",
-        type=int,
-        default=multiprocessing.cpu_count(),
-        help=("Number of workers (defaults to number of CPUs) to parallelize "
-              "the data loading. Set to a negative value to disable."))
     args = parser.parse_args()
     print(f"Arguments used: {args}")
 
@@ -77,12 +60,13 @@ if __name__ == "__main__":
     settings, embedding_dimension, storage_context = get_settings(
         args.chunk, args.overlap, args.model_dir)
 
-    # Load documents
-    os_metadata = OSMetadata(args.folder, OS_DOCS_ROOT_URL)
-    documents = process_documents(
-        args.folder, metadata_func=os_metadata.set_metadata,
-        required_exts=['.txt',], num_workers=args.workers)
+    metadata_processor = OpenstackDocsMetadataProcessor(args.folder)
 
+    # Load documents
+    documents = process_documents(
+        args.folder, metadata_func=metadata_processor.file_metadata_func,
+        required_exts=['.txt',], num_workers=args.workers)
+    unreachables = metadata_processor.n_unreachable_urls()
     # Create chunks/nodes
     nodes = settings.text_splitter.get_nodes_from_documents(documents)
 
@@ -95,5 +79,5 @@ if __name__ == "__main__":
     # Save metadata
     save_metadata(start_time, args, embedding_dimension, documents,
                   PERSIST_FOLDER)
-
-    print_unreachable_docs_warning()
+    if unreachables > 0:
+        print_unreachable_docs_warning(unreachables)


### PR DESCRIPTION
Processed documents and their URL statuses are kept in memory for later report. This eliminates need for global variable and simplifies parallelization of the code.

Genereation of embeddings for openstack was reworked to use the new callback instead of it's own implementation.

This way of handling metadata should serve as blueprint going forward. Meaning that all functions processing docs should be open to parallelization, if at all possible. 