### PR TITLE
Removing deprecated strategy

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -3,7 +3,7 @@
 
 [metadata]
 groups = ["default", "dev"]
-strategy = ["cross_platform", "inherit_metadata"]
+strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
 content_hash = "sha256:bc2a47d0f1d0983b769e4e310481480f76d42eca00030ffbdc26a610692208a9"
 


### PR DESCRIPTION
The strategy was deprecated by pdm, with justification that it's essentially the default and architecture specific lock targets are preferred. 

https://github.com/pdm-project/pdm/discussions/3037 