### PR TITLE
Fix the OpenStack RAG generation metadata

### DIFF
--- a/scripts/common_embeddings.py
+++ b/scripts/common_embeddings.py
@@ -136,8 +136,8 @@ def get_common_arg_parser() -> argparse.ArgumentParser:
         "--workers",
         default=-1,
         type=int,
-        help=("Number of workers (defaults to number of CPUs) to parallelize "
-              "the data loading. By default set to a negative value. Turning parallelism off.")
+        help=("Number of workers to parallelize the data loading. Set to a "
+              "negative value by default, turning parallelism off")
     )
     return parser
 

--- a/scripts/generate_embeddings_openstack.py
+++ b/scripts/generate_embeddings_openstack.py
@@ -26,13 +26,13 @@ OS_DOCS_ROOT_URL = "https://docs.openstack.org"
 
 class OpenstackDocsMetadataProcessor(FileMetadataProcessor):
 
-    def __init__(self, docs_path):
+    def __init__(self, docs_path, base_url):
         super().__init__()
         self._base_path = os.path.abspath(docs_path)
         if self._base_path.endswith('/'):
             self._base_path = self._base_path[:-1]
 
-        self.base_url = docs_path
+        self.base_url = base_url
 
     def url_function(self, file_path):
         return (  # noqa: E731
@@ -60,7 +60,8 @@ if __name__ == "__main__":
     settings, embedding_dimension, storage_context = get_settings(
         args.chunk, args.overlap, args.model_dir)
 
-    metadata_processor = OpenstackDocsMetadataProcessor(args.folder)
+    metadata_processor = OpenstackDocsMetadataProcessor(
+        args.folder, OS_DOCS_ROOT_URL)
 
     # Load documents
     documents = process_documents(


### PR DESCRIPTION
During some refactors we stopped using the OS_DOCS_ROOT_URL for our metadata, instead, it was pointing to the filepath in the filesystem. This led to all URLs being marked as unreacheable.

Also fix the help message of a config option which no longer defaults to the number of CPUs.