### PR TITLE
Fix -q and -k arguments for query_rag.py

### DIFF
--- a/scripts/query_rag.py
+++ b/scripts/query_rag.py
@@ -23,8 +23,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-m", "--model-path", required=True, help="path to the embedding model"
     )
-    parser.add_argument("-q", "--query", help="query to run")
-    parser.add_argument("-k", "--top-k", type=int, help="similarity_top_k")
+    parser.add_argument("-q", "--query", type=str, required=True, help="query to run")
+    parser.add_argument("-k", "--top-k", type=int, default=1, help="similarity_top_k")
     parser.add_argument("-n", "--node", help="retrieve node")
     args = parser.parse_args()
 


### PR DESCRIPTION
Both -q and -k arguments have improperly set default value and required flag. This leads to following errors if one of the args is omitted:

 - faiss complaining about k <= 0
 - 'none is not an allowed value' error from llama_index -> pydantic

This patch resolves this issue by:

 - setting a default value for -k to 1
 - setting -q as a required argument

An example of errors one might encounter when not setting `-k` or `-q`:

```
(rag-content-3.11) [stack@unicorn04 rag-content]$ python scripts/query_rag.py -p ./vector_db -x os-docs-2024_2 -m sentence-transformers/all-mpnet-base-v2 -q "OpenStack" 
LLM is explicitly disabled. Using MockLLM.
/home/stack/rag-content/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
/home/stack/rag-content/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
Traceback (most recent call last):
  File "/home/stack/lpiwowar/rag-content/scripts/query_rag.py", line 49, in <module>
    for n in retriever.retrieve(args.query):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/instrumentation/dispatcher.py", line 260, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/base/base_retriever.py", line 243, in retrieve
    nodes = self._retrieve(query_bundle)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/instrumentation/dispatcher.py", line 260, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/indices/vector_store/retrievers/retriever.py", line 101, in _retrieve
    return self._get_nodes_with_embeddings(query_bundle)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/indices/vector_store/retrievers/retriever.py", line 177, in _get_nodes_with_embeddings
    query_result = self._vector_store.query(query, **self._kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/vector_stores/faiss/base.py", line 182, in query
    dists, indices = self._faiss_index.search(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib64/python3.11/site-packages/faiss/class_wrappers.py", line 331, in replacement_search
    assert k > 0
           ^^^^^
```

OR

```
LLM is explicitly disabled. Using MockLLM.
/home/stack/rag-content/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
/home/stack/rag-content/.venv/lib/python3.11/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
Traceback (most recent call last):
  File "/home/stack/lpiwowar/rag-content/scripts/query_rag.py", line 49, in <module>
    for n in retriever.retrieve(args.query):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/instrumentation/dispatcher.py", line 260, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/llama_index/core/base/base_retriever.py", line 230, in retrieve
    RetrievalStartEvent(
  File "/home/stack/rag-content/.venv/lib/python3.11/site-packages/pydantic/v1/main.py", line 341, in __init__
    raise validation_error
pydantic.v1.error_wrappers.ValidationError: 1 validation error for RetrievalStartEvent
str_or_query_bundle
  none is not an allowed value (type=type_error.none.not_allowed)
```