### PR TITLE
Testing database after build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,13 @@ update-docs: ## Update the plaintext OCP docs in ocp-product-docs-plaintext/
 	scripts/get_runbooks.sh
 
 build-image-ocp-example: build-base-image ## Build a rag-content container image
-	podman build -t rag-content -f examples/Containerfile.ocp_lightspeed --build-arg FLAVOR=$(TORCH_GROUP) --build-arg NUM_WORKERS=$(NUM_WORKERS) .
+	podman build -t ocp-rag-content -f examples/Containerfile.ocp_lightspeed --build-arg FLAVOR=$(TORCH_GROUP) --build-arg NUM_WORKERS=$(NUM_WORKERS) .
+
+build-image-ocp-example-test: build-image-ocp-example ## Build test image for the OCP example
+	podman build -t test-rag-content -f examples/Containerfile.minimal_test .
+
+run-ocp-example-test: build-image-ocp-example-test ## Execute test image for the OCP example
+	podman run test-rag-content
 
 build-base-image: ## Build base container image
 	podman build -t $(TORCH_GROUP)-road-core-base -f Containerfile.base --build-arg FLAVOR=$(TORCH_GROUP)

--- a/examples/Containerfile.minimal_test
+++ b/examples/Containerfile.minimal_test
@@ -10,7 +10,7 @@ COPY --from=ocp-rag-content /rag/vector_db/ocp_product_docs /rag/vector_db/ocp_p
 COPY --from=ocp-rag-content /rag/embeddings_model /rag/embeddings_model
 
 # Run test on the database
-CMD pdm run query_rag.py --db-path /rag/vector_db/ocp_product_docs/$OCP_DOCS_VERSION/ \
+CMD python query_rag.py --db-path /rag/vector_db/ocp_product_docs/$OCP_DOCS_VERSION/ \
     -x ocp-product-docs-$(echo $OCP_DOCS_VERSION | sed 's/\./_/g') \
     --model-path /rag/embeddings_model \
     -t $SCORE_THRESHOLD \

--- a/examples/Containerfile.minimal_test
+++ b/examples/Containerfile.minimal_test
@@ -1,0 +1,17 @@
+ARG FLAVOR=cpu
+FROM ${FLAVOR}-road-core-base as road-core-rag-builder
+ENV OCP_DOCS_VERSION="4.15"
+ENV TEST_QUERY="What is Openshift?"
+ENV SCORE_THRESHOLD="0.6"
+
+COPY ./scripts/query_rag.py .
+
+COPY --from=ocp-rag-content /rag/vector_db/ocp_product_docs /rag/vector_db/ocp_product_docs
+COPY --from=ocp-rag-content /rag/embeddings_model /rag/embeddings_model
+
+# Run test on the database
+CMD pdm run query_rag.py --db-path /rag/vector_db/ocp_product_docs/$OCP_DOCS_VERSION/ \
+    -x ocp-product-docs-$(echo $OCP_DOCS_VERSION | sed 's/\./_/g') \
+    --model-path /rag/embeddings_model \
+    -t $SCORE_THRESHOLD \
+    --query "$TEST_QUERY"

--- a/scripts/query_rag.py
+++ b/scripts/query_rag.py
@@ -43,8 +43,12 @@ if __name__ == "__main__":
         index_id=args.product_index,
     )
     if args.node is not None:
-        print(repr(storage_context.docstore.get_node(args.node)))
+        print(storage_context.docstore.get_node(args.node))
     else:
         retriever = vector_index.as_retriever(similarity_top_k=args.top_k)
-        for n in retriever.retrieve(args.query):
-            print(repr(n))
+        nodes = retriever.retrieve(args.query)
+        if len(nodes) == 0:
+            print(f"No nodes found for query: {args.query}")
+            exit(1)
+        for n in nodes:
+            print(n)


### PR DESCRIPTION
New target allows us to verify that documents can be retrieved from the newly created database.
The thin test image uses example with database as a base layer, adding only newly modified
script for submitting queries to vector database.

Simple execution of `make run-ocp-example-test` will build the example image, the test image,
and finally spin up container with test image, executing the test.
Test parameters can be modified after build, using `--env <key>=<value>` for `podman run` command.

Script first checks if any documents were retrieved from the database. This verifies that our assumptions about index name,
database location and model location are correct, and that the database was successfully built.
Afterwards, the script checks if the most relevant [node](https://docs.llamaindex.ai/en/stable/api_reference/schema/#llama_index.core.schema.NodeWithScore) retrieved, passes the given score threshold, higher is better. 
