### PR TITLE
Simplifying dependency installation.

### DIFF
--- a/Containerfile.base
+++ b/Containerfile.base
@@ -16,8 +16,8 @@ USER 0
 WORKDIR /workdir
 ENV EMBEDDING_MODEL=sentence-transformers/all-mpnet-base-v2
 
-COPY pyproject.toml pdm.lock* Makefile ./
-RUN make install-tools && pdm config python.use_venv False && make pdm-lock-check install-deps
+COPY pyproject.toml pdm.lock* ./
+RUN pip3.11 install --upgrade pip pdm && pdm config python.use_venv False && pdm sync --group ${FLAVOR} --lockfile pdm.lock.${FLAVOR}
 
 # Test torch
 RUN if [[ $(echo $LD_LIBRARY_PATH) == *"/usr/local/cuda-12.6/compat"* ]]; then \


### PR DESCRIPTION
The lockfile check isn't strictly necessary for installation and for container even less so. By cutting out the makefile targets and using `pdm` directly. 

This should also allow container pipelines to run without triggering issues with mismatched pyproject.toml and lockfile hashes.