### PR TITLE
Install lightspeed-rag-content in the base image

### DIFF
--- a/Containerfile.base
+++ b/Containerfile.base
@@ -5,29 +5,29 @@ ARG FLAVOR
 
 FROM nvcr.io/nvidia/cuda:12.6.2-devel-ubi9 as gpu-base
 ARG FLAVOR
-RUN dnf install -y python3.11 python3.11-pip libcudnn8 libnccl git &&\
+RUN dnf install -y python3.11 python3.11-pip libcudnn8 libnccl git && \
     dnf clean all
+RUN ln -sf /usr/bin/python3.11 /usr/bin/python
 ENV LD_LIBRARY_PATH=/usr/local/cuda-12.6/compat:$LD_LIBRARY_PATH
 
 FROM ${FLAVOR}-base as road-core-rag-builder
 ARG FLAVOR
 
 USER 0
-WORKDIR /workdir
+WORKDIR /rag-content
 ENV EMBEDDING_MODEL=sentence-transformers/all-mpnet-base-v2
 
-COPY pyproject.toml pdm.lock* Makefile ./
-RUN make install-tools && pdm config python.use_venv False && make pdm-lock-check install-deps
+COPY . /rag-content
+RUN make install-global
 
 # Test torch
 RUN if [[ $(echo $LD_LIBRARY_PATH) == *"/usr/local/cuda-12.6/compat"* ]]; then \
-        pdm run python -c "import torch; print(torch.version.cuda); print(torch.cuda.is_available());"; \
+        python -c "import torch; print(torch.version.cuda); print(torch.cuda.is_available());"; \
     fi
 
-# Download embeddings model
-COPY scripts/download_embeddings_model.py .
-RUN pdm run python download_embeddings_model.py -l ./embeddings_model -r ${EMBEDDING_MODEL}
-
-COPY scripts/generate_embeddings_openshift.py ./
+# # Download embeddings model
+RUN python ./scripts/download_embeddings_model.py \
+        -l ./embeddings_model \
+        -r ${EMBEDDING_MODEL}
 
 LABEL description="Contains embedding model and dependencies needed to generate a vector database"

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ install-tools: ## Install required utilities/tools
 pdm-lock-check: ## Check that the pdm.lock file is in a good shape
 	pdm lock --check --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
 
+install-global: install-tools pdm-lock-check ## Install ligthspeed-rag-content to global Python directories
+	pdm install --global --project . --group $(TORCH_GROUP) --lockfile pdm.lock.$(TORCH_GROUP)
+
 install-hooks: install-deps-test ## Install commit hooks
 	pdm run pre-commit install
 

--- a/examples/Containerfile.ocp_lightspeed
+++ b/examples/Containerfile.ocp_lightspeed
@@ -4,7 +4,7 @@ ARG OCP_DOCS_VERSION="4.15"
 ARG NUM_WORKERS=1
 
 USER 0
-WORKDIR /workdir
+WORKDIR /rag-content
 
 COPY ./scripts/get_ocp_plaintext_docs.sh ./scripts/get_runbooks.sh ./
 COPY ./scripts/asciidoctor-text ./asciidoctor-text
@@ -16,9 +16,15 @@ RUN ./get_ocp_plaintext_docs.sh $OCP_DOCS_VERSION
 RUN ./get_runbooks.sh
 
 RUN set -e && for OCP_VERSION in $(ls -1 ocp-product-docs-plaintext); do \
-        pdm run python generate_embeddings_openshift.py -f ocp-product-docs-plaintext/${OCP_VERSION} -r runbooks/alerts -md embeddings_model \
-            -mn ${EMBEDDING_MODEL} -o vector_db/ocp_product_docs/${OCP_VERSION} -w ${NUM_WORKERS} \
-            -i ocp-product-docs-$(echo $OCP_VERSION | sed 's/\./_/g') -v ${OCP_VERSION}; \
+        python ./scripts/generate_embeddings_openshift.py \
+            -f ocp-product-docs-plaintext/${OCP_VERSION} \
+            -r runbooks/alerts \
+            -md embeddings_model \
+            -mn ${EMBEDDING_MODEL} \
+            -o vector_db/ocp_product_docs/${OCP_VERSION} \
+            -w ${NUM_WORKERS} \
+            -i ocp-product-docs-$(echo $OCP_VERSION | sed 's/\./_/g') \
+            -v ${OCP_VERSION}; \
     done
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
This commit modifies the `Containerfile.base` so that `lightspeed-rag-content` package is installed inside of the image. Right now, the building of the vector database inside of the image does not work for the OpenShift example because the package is not present.
    
Including the lightspeed-rag-content package in the base image will make it easier for other repositories (e.g., openstack-lightspeed/rag-content [1]) to use.
    
[1] https://github.com/openstack-lightspeed/rag-content

### Example of a failure 
The following error is encountered when running `make build-image-ocp-example` on `main` branch right now:
```
[1/2] STEP 12/12: RUN set -e && for OCP_VERSION in $(ls -1 ocp-product-docs-plaintext); do         pdm run python generate_embeddings_openshift.py -f ocp-product-docs-plaintext/${OCP_VERSION} -r runbooks/alerts -md embeddings_model             -mn ${EMBEDDING_MODEL} -o vector_db/ocp_product_docs/${OCP_VERSION} -w ${NUM_WORKERS}             -i ocp-product-docs-$(echo $OCP_VERSION | sed 's/\./_/g') -v ${OCP_VERSION};     done
Traceback (most recent call last):
  File "/workdir/generate_embeddings_openshift.py", line 9, in <module>
    from lightspeed_rag_content import utils
ModuleNotFoundError: No module named 'lightspeed_rag_content'

```