### PR TITLE
Fix workdir path in Containerfile.ocp_lightspeed

### DIFF
--- a/examples/Containerfile.ocp_lightspeed
+++ b/examples/Containerfile.ocp_lightspeed
@@ -28,8 +28,8 @@ RUN set -e && for OCP_VERSION in $(ls -1 ocp-product-docs-plaintext); do \
     done
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-COPY --from=road-core-rag-builder /workdir/vector_db/ocp_product_docs /rag/vector_db/ocp_product_docs
-COPY --from=road-core-rag-builder /workdir/embeddings_model /rag/embeddings_model
+COPY --from=road-core-rag-builder /rag-content/vector_db/ocp_product_docs /rag/vector_db/ocp_product_docs
+COPY --from=road-core-rag-builder /rag-content/embeddings_model /rag/embeddings_model
 
 # this directory is checked by ecosystem-cert-preflight-checks task in Konflux
 RUN mkdir /licenses


### PR DESCRIPTION
In this PR [1], the path of the WORKDIR was changed. This update required changes to the file paths for the vector db and embedding model, but the changes have not been made. This commit fixes that.

[1] https://github.com/road-core/rag-content/pull/30