### PR TITLE
Run extraction with python directly

### DIFF
--- a/scripts/get_ocp_plaintext_docs.sh
+++ b/scripts/get_ocp_plaintext_docs.sh
@@ -9,7 +9,7 @@ rm -rf ocp-product-docs-plaintext/${OCP_VERSION}
 
 git clone --single-branch --branch enterprise-${OCP_VERSION} https://github.com/openshift/openshift-docs.git
 
-pdm run scripts/asciidoctor-text/convert-it-all.py -i openshift-docs -t openshift-docs/_topic_maps/_topic_map.yml \
+python scripts/asciidoctor-text/convert-it-all.py -i openshift-docs -t openshift-docs/_topic_maps/_topic_map.yml \
     -d openshift-enterprise -o ocp-product-docs-plaintext/${OCP_VERSION} -a scripts/asciidoctor-text/${OCP_VERSION}/attributes.yaml
 
 for f in $(cat config/exclude.conf); do


### PR DESCRIPTION
Dependencies are installed globally in containers now, so we don't have to use `pdm` to run scripts. 