### PR TITLE
Build cpu and gpu image separately

### DIFF
--- a/.github/workflows/docker-base-build-publish.yml
+++ b/.github/workflows/docker-base-build-publish.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-    IMAGE_NAME: ${{ github.event.repository.name }}
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:
@@ -39,13 +38,13 @@ jobs:
         id: build_image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: ${{ env.IMAGE_NAME }}
-          tags: latest-${{ matrix.architecture }} ${{ github.sha }}-${{ matrix.architecture }}
+          image: ${{ github.event.repository.name }}-${{ matrix.architecture }}
+          tags: latest ${{ github.sha }}
           oci: true
           build-args: FLAVOR=${{ matrix.architecture }}
           containerfiles: |
             ./Containerfile.base
-                                                                            
+
       # Push the image to GHCR (Image Registry)
       - name: Push To GHCR
         uses: redhat-actions/push-to-registry@v2


### PR DESCRIPTION
This commit splits the road-core container image into two:

- road-core-cpu: contains dependencies for building of the vector DB using CPU.

- road-core-gpu: contains dependencies for building of the vector DB using GPU.