### PR TITLE
Extend README with information on the new library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ implementations.
 ## Installing the Python library
 
 The ``lightspeed_rag_content`` library is not available via pip but is included
-in the base container image. To use it, you can manually generate or pull the
-base container image as follows:
+in the base container image or can be installed via ``pdm``.
+
+### Via container image
+
+The base container image can be manually generated or pulled from a
+container registry.
 
 1. Install the requirements: ``make`` and ``podman``.
 
@@ -34,7 +38,24 @@ lightspeed_rag_content
 Alternatively, to pull the latest version of the base container image, run:
 
 ```bash
-podman pull ghcr.io/road-core/rag-content-cpu:latest
+$ podman pull ghcr.io/road-core/rag-content-cpu:latest
+```
+
+### Via PDM
+
+To install the library via PDM, do:
+
+1. Run the command ``pdm install``
+
+```bash
+$ pdm install
+```
+
+2. Test if the library can be imported
+
+```bash
+$ pdm run python -c "import lightspeed_rag_content; print(lightspeed_rag_content.__name__)"
+lightspeed_rag_content
 ```
 
 ## Using the Python library

--- a/README.md
+++ b/README.md
@@ -1,5 +1,82 @@
 # Road RAG content
 
+Road Rag Content provides a shared codebase for generating Retrieval-Augmented
+Generation (RAG) vector databases. It serves as the core framework for projects
+like OpenShift Lightspeed and OpenStack Lightspeed to generate their own RAG
+vector databases.
+
+This project includes the ``lightspeed_rag_content`` library, along with some
+additional utilities to consistency and efficiency across multiple
+implementations.
+
+## Installing the Python library
+
+The ``lightspeed_rag_content`` library is not available via pip but is included
+in the base container image. To use it, you can manually generate or pull the
+base container image as follows:
+
+1. Install the requirements: ``make`` and ``podman``.
+
+2. Generate the base container image
+
+```bash
+$ make build-base-image FLAVOR=cpu
+```
+
+3. The ``lightspeed_rag_content`` and its dependencies will be installed in the
+image:
+
+```bash
+$ podman run localhost/cpu-road-core-base:latest python -c "import lightspeed_rag_content; print(lightspeed_rag_content.__name__)"
+lightspeed_rag_content
+```
+
+Alternatively, to pull the latest version of the base container image, run:
+
+```bash
+podman pull ghcr.io/road-core/rag-content-cpu:latest
+```
+
+## Using the Python library
+
+Let’s say you’re working on another Lightspeed project and you need to generate
+a RAG vector database from a set of documents. Instead of starting from scratch,
+you just inherit ``lightspeed_rag_content`` library and use its abstractions:
+
+Here’s an example:
+
+```python
+from lightspeed_rag_content.metadata_processor import MetadataProcessor
+from lightspeed_rag_content.document_processor import DocumentProcessor
+
+
+class CustomMetadataProcessor(MetadataProcessor):
+
+    def __init__(self, url):
+        ...
+
+    def url_function(self, file_path):
+        # Return a URL for the file, so it can be referenced when used
+        # in an answer
+        ...
+
+# Instantiate custom Metadata Processor
+metadata_processor = CustomMetadataProcessor("www.my-project.com")
+
+# Instantiate Document Processor
+document_processor = DocumentProcessor(
+    chunk_size, chunk_overlap, model_name, model_dir, num_workers,
+    vector_store_type
+)
+
+# Load and embed the the documents, this method can be called multiple times
+# for different sets of documents
+document_processor.process(docs_path, metadata=metadata_processor)
+
+# Save the new vector database to the output directory
+document_processor.save(index, output_path)
+```
+
 # Generating the RAG for OpenShift
 
 This guide outlines the steps for generating an example OpenShift Lightspeed
@@ -64,7 +141,7 @@ You can generate the RAG vector database either using
 
 #### Faiss Vector Store
 
-In order to generate the RAG vector database using 
+In order to generate the RAG vector database using
 Faiss Vector Store with
 the
 **sentend-transformers/all-mpnet-base-v2** embedding model and OpenShift
@@ -85,7 +162,7 @@ Lightspeed.
 
 #### Postgres (PGVector) Vector Store
 
-In order to generate the RAG vector database using 
+In order to generate the RAG vector database using
 Postgres (PGVector) Vector Store run the following commands:
 
 1. Start Postgres with the pgvector extension by running
@@ -93,7 +170,7 @@ Postgres (PGVector) Vector Store run the following commands:
     make start-postgres-debug
     ```
    The `data` folder of Postgres is created at
-   `./postgresql/data`. This command also creates `./output` for the 
+   `./postgresql/data`. This command also creates `./output` for the
    output directory, in which the metadata is saved.
 2. Run
     ```
@@ -108,14 +185,14 @@ Postgres (PGVector) Vector Store run the following commands:
    root@42b7f8fcfe9b:/# psql -U postgres
    psql (16.4 (Debian 16.4-1.pgdg120+2))
    Type "help" for help.
-   
+
    postgres=# \dt
                       List of relations
-    Schema |            Name            | Type  |  Owner   
+    Schema |            Name            | Type  |  Owner
    --------+----------------------------+-------+----------
     public | data_ocp_product_docs_4_15 | table | postgres
    (1 row)
-   
+
    postgres=#
    ```
 
@@ -134,3 +211,8 @@ The following command must be executed:
 ```bash
 scripts/generate_packages_to_prefetch.py
 ```
+
+# License
+
+This project is licensed under the Apache License 2.0. See the **LICENSE** file
+for details.


### PR DESCRIPTION
This PR extends the README file to include information how the new lightspeed_rag_content Python library is distributed and its usage.

The README already contains information about how to set up and generate a RAG image for OpenShift Lightspeed, so this have not been modified.

Nit but worth mentioning, information about the LICENSE has also been added to the README file.