### PR TITLE
Optionally drop or fail on unreachable URLs

### DIFF
--- a/tests/test_metadata_processor.py
+++ b/tests/test_metadata_processor.py
@@ -82,7 +82,7 @@ class TestMetadataProcessor(unittest.TestCase):
 
         result = self.md_processor.populate(self.file_path)
 
-        expected_result = {"docs_url": self.url, "title": self.title}
+        expected_result = {"docs_url": self.url, "title": self.title, "url_reachable": True}
         self.assertEqual(expected_result, result)
 
     @mock.patch.object(metadata_processor.MetadataProcessor, "ping_url")
@@ -98,6 +98,6 @@ class TestMetadataProcessor(unittest.TestCase):
                              level="WARNING") as log:
             result = self.md_processor.populate(self.file_path)
 
-        expected_result = {"docs_url": self.url, "title": self.title}
+        expected_result = {"docs_url": self.url, "title": self.title, "url_reachable": False}
         self.assertEqual(expected_result, result)
         self.assertIn("URL not reachable", log.output[0])


### PR DESCRIPTION
* Currently we only get a WARNING when the URL is unreachable
* Adds the option to drop docs when the URL is unreachable
  * Useful for ad-hoc or in-progress work on a new corpus
* Add the option to fail the build when a URL is unreachable
  * Useful for production builds where every URL is expected to be live
* Also adds retries to the ping_url to combat false failures